### PR TITLE
Injectable logger

### DIFF
--- a/src/main/scala/io/shaka/http/HttpServer.scala
+++ b/src/main/scala/io/shaka/http/HttpServer.scala
@@ -2,13 +2,13 @@ package io.shaka.http
 
 import java.net.InetSocketAddress
 
-import com.sun.net.httpserver.{HttpServer => SunHttpServer}
+import com.sun.net.httpserver.{HttpServer ⇒ SunHttpServer}
 import io.shaka.http.Http.HttpHandler
+import io.shaka.http.HttpServer.ToLog
 import io.shaka.http.Response.respond
 import io.shaka.http.Status.NOT_FOUND
 
-
-class HttpServer(private val usePort:Int = 0) {
+class HttpServer(private val usePort:Int = 0, otherLog: ToLog) {
 
   val server =  SunHttpServer.create(new InetSocketAddress(usePort), 0)
   server.setExecutor(null)
@@ -18,7 +18,7 @@ class HttpServer(private val usePort:Int = 0) {
     val startedAt = System.nanoTime()
     server.start()
     val elapsedTime = BigDecimal((System.nanoTime() - startedAt) / 1000000.0).formatted("%.2f")
-    println(s"naive-http-server started on port ${port()} in $elapsedTime milli seconds")
+    otherLog(s"naive-http-server started on port ${port()} in $elapsedTime milli seconds")
     this
   }
 
@@ -38,8 +38,10 @@ class HttpServer(private val usePort:Int = 0) {
 }
 
 object HttpServer {
-  def apply(): HttpServer = apply(0)
-  def apply(port: Int): HttpServer = new HttpServer(port)
-  def apply(handler: HttpHandler, port: Int = 0): HttpServer = apply(port).handler(handler)
-}
+  type ToLog = String => Unit
+  private val printlnLog: ToLog = (s) => println(s)
 
+  def apply(): HttpServer = apply(0)
+  def apply(port: Int): HttpServer = new HttpServer(port, printlnLog)
+  def apply(handler: HttpHandler, port: Int = 0, log: ToLog = printlnLog): HttpServer = new HttpServer(port, log).handler(handler)
+}

--- a/src/test/scala/io/shaka/http/HttpServerSpec.scala
+++ b/src/test/scala/io/shaka/http/HttpServerSpec.scala
@@ -3,11 +3,14 @@ package io.shaka.http
 import io.shaka.http.ContentType._
 import io.shaka.http.Http.http
 import io.shaka.http.HttpHeader.{CONTENT_LENGTH, USER_AGENT}
+import io.shaka.http.HttpServer.ToLog
 import io.shaka.http.HttpServerSpecSupport.withHttpServer
 import io.shaka.http.Request.{GET, HEAD, POST}
 import io.shaka.http.Response.respond
 import io.shaka.http.Status.{INTERNAL_SERVER_ERROR, NOT_FOUND}
 import org.scalatest.FunSuite
+
+import scala.collection.mutable
 
 class HttpServerSpec extends FunSuite {
 
@@ -102,6 +105,17 @@ class HttpServerSpec extends FunSuite {
       assert(response.entity === None)
       assert(response.header(CONTENT_LENGTH) === Some("Hello world".length.toString))
     }
+  }
+
+  test("output the port the server has started on") {
+    val loggedMessages = mutable.MutableList[String]()
+    val captureMessage: ToLog = (s) ⇒ loggedMessages += s
+
+    val httpServer = new HttpServer(0, captureMessage).start()
+
+    assert(loggedMessages.exists(m ⇒ m.startsWith(s"naive-http-server started on port ${httpServer.port()}")))
+
+    httpServer.stop()
   }
 }
 


### PR DESCRIPTION
Default implementation wraps the original println.

HttpServer objects factory methods are a little bit messier but hopefully backward compatible.